### PR TITLE
draw_text8x8: Fix off-by-one

### DIFF
--- a/ssd1309.py
+++ b/ssd1309.py
@@ -540,7 +540,7 @@ class Display(object):
             text (string): Text to draw.
         """
         # Confirm coordinates in boundary
-        if self.is_off_grid(x, y, x + 8, y + 8):
+        if self.is_off_grid(x, y, x + 7, y + 7):
             return
         self.monoFB.text(text, x, y)
 


### PR DESCRIPTION
## Steps to reproduce

```python
display.draw_text8x8(15 * 8, 0, "A")
display.draw_text8x8(0, 7 * 8, "A")

# x-coordinate: 128 above maximum of 127.
# y-coordinate: 64 above maximum of 63.
```

## Rationale

- Coordinates `(120, 0)` or `(0, 56)` are within range for 8x8 text

## Other

- Additionally, the `draw_text8x8` doesn't check how long the string is, so the bounds check can be bypassed that way, though I don't consider it much of an issue since [the underlying `FrameBuffer.text` implementation appears to ignore anything out-of-bounds](https://github.com/micropython/micropython/blob/8995a291e05aef6c2ab1a24647355eae87dca391/extmod/modframebuf.c#L851-L855)